### PR TITLE
Fix up UNAME for Solaris build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,9 @@ elif UNAME == 'Windows':
 elif UNAME == 'Linux':
     # necessary when EPICS is statically linked
     libraries += ['readline', 'rt']
+elif UNAME == 'SunOS':
+    # OS_CLASS used by EPICS
+    UNAME = 'solaris'
 
 cas_module = Extension('pcaspy._cas',
                        sources  =[os.path.join('pcaspy','casdef.i'),


### PR DESCRIPTION
Hi,
To build pcaspy on Solaris, I found I needed to tweak the setup.py file.  This is because, on Solaris, platform.system() returns 'SunOS' whereas EPICS uses 'solaris' for OS_CLASS and therefore the include file path.

(P.S. This is my first ever pull request , so I hope I've understood the procedure OK)
