### PR TITLE
Add getParamInfo-method to Driver

### DIFF
--- a/pcaspy/driver.py
+++ b/pcaspy/driver.py
@@ -266,6 +266,33 @@ class Driver(DriverBase):
 
         return self.pvDB[reason]
 
+    def getParamInfo(self, reason, info_keys=None):
+        """
+        Get PV info fields. This function returns a dictionary with info/value pairs,
+        where each entry of the info_keys-parameter results in a dictionary entry if
+        the PVInfo-object has such an attribute. Attributes that do not exist are ignored.
+        Valid attributes are the same as used in :meth:`SimpleServer.createPV`.
+
+        If no info_keys are specified, all PV info keys are returned.
+
+        :param reason: PV base name
+        :param info_keys: List of keys for what information to obtain
+        :return: Dictionary with PV info fields and their current values
+        """
+        pv = manager.pvs[self.port][reason]
+
+        if info_keys is None:
+            info_keys = ['states', 'prec', 'unit', 'lolim', 'hilim',
+                         'hihi', 'lolo', 'high', 'low', 'scan', 'asyn',
+                         'asg', 'port', 'enums', 'count', 'type', 'value']
+
+        info_dict = {}
+        for key in info_keys:
+            if hasattr(pv.info, key):
+                info_dict[key] = getattr(pv.info, key)
+
+        return info_dict
+
     def callbackPV(self, reason):
         """Inform asynchronous write completion
 


### PR DESCRIPTION
I hope it's alright that I open this PR and that it makes some sense - if not, let me know what has to be improved.

The motivation for this is that we have been developing a device simulation package (https://github.com/DMSC-Instrument-Data/lewis), and our EPICS-interface mechanism is based on your `pcaspy` module (it works great, thanks for developing this library!). Some time ago we added an option to modify PV meta data (such as limits) at runtime, but now we wanted to be more selective about when to forward such updates to `pcaspy` at all. That requires a way of querying the values of these meta-data.

So this PR adds a `getParamInfo`-method that provides such a way. As a workaround for our project we access `pcaspy.driver.manager` directly, but that seems like a bad idea as `manager` is not part of the public interface and may break in the future. For the implementation I followed the implementation of `setParamInfo`.

Please let me know if you need any further information.