### PR TITLE
avoid race condition when calling SimplePV.updateValue()

### DIFF
--- a/pcaspy/driver.py
+++ b/pcaspy/driver.py
@@ -310,8 +310,8 @@ class Driver(DriverBase):
         """
         pv = manager.pvs[self.port][reason]
         if self.pvDB[reason].flag and pv.info.scan == 0:
-            pv.updateValue(self.pvDB[reason])
             self.pvDB[reason].flag = False
+            pv.updateValue(self.pvDB[reason])
             self.pvDB[reason].mask = 0
 
 
@@ -502,8 +502,8 @@ class SimplePV(cas.casPV):
                 # post update events if necessary
                 dbValue = driver.getParamDB(self.info.reason)
                 if dbValue.flag:
-                    self.updateValue(dbValue)
                     dbValue.flag = False
+                    self.updateValue(dbValue)
                     dbValue.mask = 0
             time.sleep(self.info.scan)
 


### PR DESCRIPTION
PV records are ultimately updated in the SimplePV.updateValue() method.
This method is called in two places in the code: in SimplePV's scan()
method, which is run in a separate thread, and in calls to Driver.updatePVs().
which is usually executed manually in user code.  A lack of synchronization
in these calls allows for possible collisions in the record updates, which
seem to manifest in occasional redundant updates as see by clients.

This patch reorders the sequence of calls around updateValue() to use the
update flag as an effective synchronization token.  Since the updateValue()
method is only called if the PV "flag" is True, resetting the flag right
before the call, instead of right after, seems to prevent the double updates.