### PR TITLE
Fix python38 windows build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ elif UNAME == 'Windows':
                 static = True
                 break
             dll_dest = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pcaspy', dll)
-            if not os.path.exists(dll_dest):
+            if sys.argv[1] == "install":
                 shutil.copy(dllpath, dll_dest)
         macros += [('_CRT_SECURE_NO_WARNINGS', 'None'), ('_CRT_NONSTDC_NO_DEPRECATE', 'None'), ('EPICS_CALL_DLL', '')]
         cflags += ['/Z7']

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import platform
 import sys
 import shutil
 import subprocess
+import filecmp
 
 # Use setuptools to include build_sphinx, upload/sphinx commands
 try:
@@ -92,7 +93,7 @@ elif UNAME == 'Windows':
                 static = True
                 break
             dll_dest = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pcaspy', dll)
-            if sys.argv[1] == "install":
+            if not os.path.exists(dll_dest) or not filecmp.cmp(dllpath, dll_dest):
                 shutil.copy(dllpath, dll_dest)
         macros += [('_CRT_SECURE_NO_WARNINGS', 'None'), ('_CRT_NONSTDC_NO_DEPRECATE', 'None'), ('EPICS_CALL_DLL', '')]
         cflags += ['/Z7']

--- a/setup.py
+++ b/setup.py
@@ -91,8 +91,9 @@ elif UNAME == 'Windows':
             if not os.path.exists(dllpath):
                 static = True
                 break
-            shutil.copy(dllpath,
-                        os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pcaspy'))
+            dll_dest = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pcaspy')
+            if not os.path.exists(dll_dest):
+                shutil.copy(dllpath, dll_dest)
         macros += [('_CRT_SECURE_NO_WARNINGS', 'None'), ('_CRT_NONSTDC_NO_DEPRECATE', 'None'), ('EPICS_CALL_DLL', '')]
         cflags += ['/Z7']
         CMPL = 'msvc'

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ elif UNAME == 'Windows':
             if not os.path.exists(dllpath):
                 static = True
                 break
-            dll_dest = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pcaspy')
+            dll_dest = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pcaspy', dll)
             if not os.path.exists(dll_dest):
                 shutil.copy(dllpath, dll_dest)
         macros += [('_CRT_SECURE_NO_WARNINGS', 'None'), ('_CRT_NONSTDC_NO_DEPRECATE', 'None'), ('EPICS_CALL_DLL', '')]


### PR DESCRIPTION
Only copy DLLs if they're not already present in the build.

This is similar to https://github.com/CaChannel/CaChannel/pull/4 and fixes pip installs under windows 10 and python 3.8