### PR TITLE
installation.rst: fix for EPICS 7 instructions

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -88,10 +88,12 @@ Here is a short guide,
   - Download source from https://github.com/epics-modules/pcas/releases
   - Unpack its contents to <EPICS_BASE>/modules/pcas
   - Create <EPICS_BASE>/modules/Makefile.local, with the following contents::
+  
+        SUBMODULES += pcas
+        pcas_DEPEND_DIRS = libcom
 
-    SUBMODULES += pcas
-    pcas_DEPEND_DIRS = libcom
-
+  - As long as v4.13.2 is the latest release of pcas, add ``-include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local``
+    to the end of <EPICS_BASE>/modules/pcas/configure/RELEASE.
 - Run ``make``.
 
 .. note:: On windows, the Visual Studio version has to match that used to build Python.


### PR DESCRIPTION
* Fixes the literal block containing the additional lines for Makefile.local
* Adds a note on required change of pcas/configure/RELEASE
  as long as commit epics-modules/pcas@ac5ff32
  hasn't made it into a new release.