### PR TITLE
Update daemonising of scan PVs

### DIFF
--- a/pcaspy/driver.py
+++ b/pcaspy/driver.py
@@ -513,7 +513,7 @@ class SimplePV(cas.casPV):
         # scan thread
         if self.info.scan > 0:
             self.tid = threading.Thread(target=self.scan)
-            self.tid.setDaemon(True)
+            self.tid.daemon = True
             self.tid.start()
 
     def scan(self):


### PR DESCRIPTION
Closes https://github.com/paulscherrerinstitute/pcaspy/issues/96 .

The `setDaemon()` call is deprecated in Python 3.10. Instead the attribute is used.